### PR TITLE
Switches argparse key for bag-dir from '-d' to '-g'

### DIFF
--- a/src/rqt_py_trees/behaviour_tree.py
+++ b/src/rqt_py_trees/behaviour_tree.py
@@ -304,7 +304,7 @@ class RosBehaviourTree(QObject):
 
         operate_object.add_argument('bag', action='store', nargs='?', help='Load this bag when the viewer starts')
         operate_object.add_argument('-l', '--latest-bag', action='store_true', help='Load the latest bag available in the bag directory. Bag files are expected to be under the bag directory in the following structure: year-month-day/behaviour_tree_hour-minute-second.bag. If this structure is not followed, the bag file which was most recently modified is used.')
-        operate_object.add_argument('-d', '--bag-dir', action='store', help='Specify the directory in which to look for bag files. The default is $ROS_HOME/behaviour_trees, if $ROS_HOME is set, or ~/.ros/behaviour_trees otherwise.')
+        operate_object.add_argument('-g', '--bag-dir', action='store', help='Specify the directory in which to look for bag files. The default is $ROS_HOME/behaviour_trees, if $ROS_HOME is set, or ~/.ros/behaviour_trees otherwise.')
         operate_object.add_argument('-m', '--by-time', action='store_true', help='The latest bag is defined by the time at which the file was last modified, rather than the date and time specified in the filename.')
         operate_object.add_argument(RosBehaviourTree.no_roscore_switch, action='store_true', help='Run the viewer without roscore. It is only possible to view bag files if this is set.')
 

--- a/src/rqt_py_trees/behaviour_tree.py
+++ b/src/rqt_py_trees/behaviour_tree.py
@@ -304,7 +304,7 @@ class RosBehaviourTree(QObject):
 
         operate_object.add_argument('bag', action='store', nargs='?', help='Load this bag when the viewer starts')
         operate_object.add_argument('-l', '--latest-bag', action='store_true', help='Load the latest bag available in the bag directory. Bag files are expected to be under the bag directory in the following structure: year-month-day/behaviour_tree_hour-minute-second.bag. If this structure is not followed, the bag file which was most recently modified is used.')
-        operate_object.add_argument('-g', '--bag-dir', action='store', help='Specify the directory in which to look for bag files. The default is $ROS_HOME/behaviour_trees, if $ROS_HOME is set, or ~/.ros/behaviour_trees otherwise.')
+        operate_object.add_argument('--bag-dir', action='store', help='Specify the directory in which to look for bag files. The default is $ROS_HOME/behaviour_trees, if $ROS_HOME is set, or ~/.ros/behaviour_trees otherwise.')
         operate_object.add_argument('-m', '--by-time', action='store_true', help='The latest bag is defined by the time at which the file was last modified, rather than the date and time specified in the filename.')
         operate_object.add_argument(RosBehaviourTree.no_roscore_switch, action='store_true', help='Run the viewer without roscore. It is only possible to view bag files if this is set.')
 


### PR DESCRIPTION
In [qt_gui_core](https://github.com/ros-visualization/qt_gui_core/pull/69/files), '-d' is taken for '--disable-init-threads'.

`b` is also not vacant.

Solution for issue #8 