### PR TITLE
Added python-pygraphviz run dependency

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -37,6 +37,7 @@
   <run_depend>py_trees_msgs</run_depend>
   <run_depend>rqt_bag</run_depend>
   <run_depend>unique_id</run_depend>
+  <run_depend>python-pygraphviz</run_depend>
 
   <test_depend>python-mock</test_depend>
 


### PR DESCRIPTION
When installing the py_trees suite from the ROS repos and trying to run the tutorials I get:
```
Traceback (most recent call last):
  File "/opt/ros/kinetic/lib/rqt_py_trees/rqt_py_trees", line 10, in <module>
    from rqt_py_trees.behaviour_tree import RosBehaviourTree
  File "/opt/ros/kinetic/lib/python2.7/dist-packages/rqt_py_trees/__init__.py", line 16, in <module>
    from . import behaviour_tree
  File "/opt/ros/kinetic/lib/python2.7/dist-packages/rqt_py_trees/behaviour_tree.py", line 55, in <module>
    from qt_dotgraph.dot_to_qt import DotToQtGenerator
  File "/opt/ros/kinetic/lib/python2.7/dist-packages/rqt_py_trees/qt_dotgraph/__init__.py", line 21, in <module>
    from . import dot_to_qt
  File "/opt/ros/kinetic/lib/python2.7/dist-packages/rqt_py_trees/qt_dotgraph/dot_to_qt.py", line 23, in <module>
    import pygraphviz
ImportError: No module named pygraphviz
```

As pygraphviz is defined in [python's rosdistro](https://github.com/ros/rosdistro/blob/master/rosdep/python.yaml) I just add its name to resolve the dependency.

Tested in Kubuntu 16.04 and ROS kinetic.