### PR TITLE
Quick fix: Add Python3 version check to dynamic_timeline_frame to con…

### DIFF
--- a/src/rqt_py_trees/dynamic_timeline_frame.py
+++ b/src/rqt_py_trees/dynamic_timeline_frame.py
@@ -30,7 +30,6 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-
 from python_qt_binding.QtCore import qDebug, QPointF, QRectF, Qt, qWarning, Signal
 from python_qt_binding.QtGui import QBrush, QCursor, QColor, QFont, \
                                     QFontMetrics, QPen, QPolygonF
@@ -39,6 +38,7 @@ try:  # indigo
 except ImportError:  # kinetic+ (pyqt5)
     from python_qt_binding.QtWidgets import QGraphicsItem
 
+import sys
 import rospy
 import bisect
 import threading
@@ -307,6 +307,8 @@ class DynamicTimelineFrame(QGraphicsItem):
             trimmed = ''
             split_name = topic_name.split('/')
             split_name = filter(lambda a: a != '', split_name)
+            if sys.version_info[0] > 2:
+                split_name = [n for n in split_name]
             #  Save important last element of topic name provided it is small
             popped_last = False
             if self._qfont_width(split_name[-1]) < .5 * allowed_width:


### PR DESCRIPTION
I found a small issue in `dynamic_timeline_frame.py` in its use of filters from Python2 to Python3. This was making `rqt_py_trees` fail in ROS Noetic since that uses Python3.

Here is a quick fix that converts the filter output from an iterator to a list if the user is running Python3. There are more clever ways to not have to convert to a list and directly deal with the iterator, but based on how this output is consumed afterwards, I think a conversion to list is appropriate.